### PR TITLE
This is a temporary camera fix for Android 10

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
         android:theme="@style/AppTheme"


### PR DESCRIPTION
This is why the camera wouldn't work, because it wasn't able to access storage. This fix is only temporary though, and a much better fix will be needed when Android 11 comes out (as scoped storage is forced then).